### PR TITLE
Exercise 04_pig_latin

### DIFF
--- a/04_pig_latin/pig_latin.rb
+++ b/04_pig_latin/pig_latin.rb
@@ -1,20 +1,23 @@
 # frozen_string_literal: true
-PHONEMES = %w[sch qu]
-
 def translate (text)
-  text.split.map { |word|
+  translation = text.split.map { |word|
     translate_word(word)
   }.join(" ")
 end
 
 def translate_word(word)
-  if /[aeiou]/i.match(word[0])
-    word << "ay"
-  elsif /[qu].*/i.match(word)
-    parts = word.split(/([aeio].*)/)
-    parts[1] << parts[0] << "ay"
+  prefix_punctuation = word[/^\W+/] || ""
+  suffix_punctuation = word[/\W+$/] || ""
+  word_without_punctuation = word[/\A\W*(\w+)\W*\z/, 1] || word
+
+  if /[aeiou]/i.match(word_without_punctuation[0])
+    word_without_punctuation << "ay"
+  elsif /[qu].*/i.match(word_without_punctuation)
+    parts = word_without_punctuation.split(/([aeio].*)/)
+    word_without_punctuation = parts[1] << parts[0] << "ay"
   else
-    parts = word.split(/([aeiou].*)/)
-    parts[1] << parts[0] << "ay"
+    parts = word_without_punctuation.split(/([aeiou].*)/)
+    word_without_punctuation = parts[1] << parts[0] << "ay"
   end
+  prefix_punctuation + word_without_punctuation + suffix_punctuation
 end

--- a/04_pig_latin/pig_latin.rb
+++ b/04_pig_latin/pig_latin.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+PHONEMES = %w[sch qu]
+
+def translate (text)
+  text.split.map { |word|
+    translate_word(word)
+  }.join(" ")
+end
+
+def translate_word(word)
+  if /[aeiou]/i.match(word[0])
+    word << "ay"
+  elsif /[qu].*/i.match(word)
+    parts = word.split(/([aeio].*)/)
+    parts[1] << parts[0] << "ay"
+  else
+    parts = word.split(/([aeiou].*)/)
+    parts[1] << parts[0] << "ay"
+  end
+end

--- a/04_pig_latin/pig_latin.rb
+++ b/04_pig_latin/pig_latin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 def translate (text)
-  translation = text.split.map { |word|
+  text.split.map { |word|
     translate_word(word)
   }.join(" ")
 end

--- a/04_pig_latin/pig_latin.rb
+++ b/04_pig_latin/pig_latin.rb
@@ -14,13 +14,11 @@ def translate_word(word)
 
   if /[aeiou]/i.match(word_without_punctuation[0])
     word_without_punctuation << "ay"
-  elsif /[qu].*/i.match(word_without_punctuation)
-    parts = word_without_punctuation.split(/([aeio].*)/)
-    word_without_punctuation = parts[1] << parts[0] << "ay"
   else
-    parts = word_without_punctuation.split(/([aeiou].*)/)
-    word_without_punctuation = parts[1] << parts[0] << "ay"
+    parts = word_without_punctuation.split(/(^[^aeiou]{0,}qu)|(^[^aeiou]{1,})/i)
+    word_without_punctuation = parts[2] << parts[1] << "ay"
   end
+
   if was_capitalized
     word_without_punctuation.capitalize!
   end

--- a/04_pig_latin/pig_latin.rb
+++ b/04_pig_latin/pig_latin.rb
@@ -10,6 +10,8 @@ def translate_word(word)
   suffix_punctuation = word[/\W+$/] || ""
   word_without_punctuation = word[/\A\W*(\w+)\W*\z/, 1] || word
 
+  was_capitalized = word_without_punctuation[0] == word_without_punctuation[0].upcase
+
   if /[aeiou]/i.match(word_without_punctuation[0])
     word_without_punctuation << "ay"
   elsif /[qu].*/i.match(word_without_punctuation)
@@ -19,5 +21,9 @@ def translate_word(word)
     parts = word_without_punctuation.split(/([aeiou].*)/)
     word_without_punctuation = parts[1] << parts[0] << "ay"
   end
+  if was_capitalized
+    word_without_punctuation.capitalize!
+  end
+
   prefix_punctuation + word_without_punctuation + suffix_punctuation
 end

--- a/04_pig_latin/pig_latin_spec.rb
+++ b/04_pig_latin/pig_latin_spec.rb
@@ -17,7 +17,7 @@
 #
 #
 
-require "pig_latin"
+require_relative "pig_latin"
 
 describe "#translate" do
 

--- a/04_pig_latin/pig_latin_spec.rb
+++ b/04_pig_latin/pig_latin_spec.rb
@@ -68,13 +68,13 @@ describe "#translate" do
   # Test-driving bonus:
   # * write a test asserting that capitalized words are still capitalized (but with a different initial capital letter, of course)
   # * retain the punctuation from the original phrase
-  it "translation keeps capital letters as they are in the original phrase" do
+  it "translation capitalizes the first letter if the word was capitalized in the original text" do
     s = translate("The quick Brown fox")
-    s.should == "eThay ickquay ownBray oxfay"
+    s.should == "Ethay ickquay Ownbray oxfay"
   end
 
   it "translation keeps punctuation same as in the original phrase" do
     s = translate("'The quick', Brown fox!")
-    s.should == "'eThay ickquay', ownBray oxfay!"
+    s.should == "'Ethay ickquay', Ownbray oxfay!"
   end
 end

--- a/04_pig_latin/pig_latin_spec.rb
+++ b/04_pig_latin/pig_latin_spec.rb
@@ -60,6 +60,11 @@ describe "#translate" do
     s.should == "aresquay"
   end
 
+  it "counts 'qu' as a consonant even when it's followed by a consonant" do
+    s = translate("qubit")
+    s.should == "bitquay"
+  end
+
   it "translates many words" do
     s = translate("the quick brown fox")
     s.should == "ethay ickquay ownbray oxfay"

--- a/04_pig_latin/pig_latin_spec.rb
+++ b/04_pig_latin/pig_latin_spec.rb
@@ -68,5 +68,13 @@ describe "#translate" do
   # Test-driving bonus:
   # * write a test asserting that capitalized words are still capitalized (but with a different initial capital letter, of course)
   # * retain the punctuation from the original phrase
+  it "translation keeps capital letters as they are in the original phrase" do
+    s = translate("The quick Brown fox")
+    s.should == "eThay ickquay ownBray oxfay"
+  end
 
+  it "translation keeps punctuation same as in the original phrase" do
+    s = translate("'The quick', Brown fox!")
+    s.should == "'eThay ickquay', ownBray oxfay!"
+  end
 end


### PR DESCRIPTION
- method for translating a word in pig latin:
        save the punctuation (prefix and suffix)
        translate the word
        add the punctuation back to the word if it previously had any
- translate(text) method which splits a string into multiple words
- added tests for checking if the punctuation was correctly maintained in the translation and words are capitalized properly